### PR TITLE
Servlet Practice

### DIFF
--- a/week4/ServletPractice/.gitignore
+++ b/week4/ServletPractice/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/week4/ServletPractice/.idea/.gitignore
+++ b/week4/ServletPractice/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/week4/ServletPractice/pom.xml
+++ b/week4/ServletPractice/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>ServletPractice</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/jakarta.servlet/jakarta.servlet-api -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.6</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20250517</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <finalName>user-crud-servlet</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/week4/ServletPractice/src/main/java/com/example/servlet/UserServlet.java
+++ b/week4/ServletPractice/src/main/java/com/example/servlet/UserServlet.java
@@ -1,0 +1,210 @@
+package com.example.servlet;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.*;
+
+// Using annotation; if using web.xml, remove @WebServlet
+//@WebServlet(urlPatterns = "/users/*")
+public class UserServlet extends HttpServlet {
+    // Database credentials & URL
+    private static final String URL = "jdbc:postgresql://localhost:5432/postgres";
+    //private static final String USER = "postgres";
+    //private static final String PASSWORD = "your_password";
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        try {
+            Class.forName("org.postgresql.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new ServletException("PostgreSQL JDBC Driver not found.", e);
+        }
+    }
+
+    // Helper: Parse JSON from request body
+    private JSONObject parseRequestBody(HttpServletRequest request) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader reader = request.getReader();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            sb.append(line);
+        }
+        return new JSONObject(sb.toString());
+    }
+
+    // Helper: Send JSON response
+    private void sendJsonResponse(HttpServletResponse response, JSONObject obj, int status) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(status);
+        PrintWriter out = response.getWriter();
+        out.print(obj.toString());
+        out.flush();
+    }
+
+    // GET /users        → list all users
+    // GET /users/{id}   → get one user
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String pathInfo = request.getPathInfo(); // null, "/", or "/{id}"
+        try (Connection conn = DriverManager.getConnection(URL)) {
+            if (pathInfo == null || pathInfo.equals("/") || pathInfo.isEmpty()) {
+                // List all users
+                String sql = "SELECT id, name, email FROM users";
+                PreparedStatement ps = conn.prepareStatement(sql);
+                ResultSet rs = ps.executeQuery();
+                JSONArray users = new JSONArray();
+
+                while (rs.next()) {
+                    JSONObject user = new JSONObject();
+                    user.put("id", rs.getInt("id"));
+                    user.put("name", rs.getString("name"));
+                    user.put("email", rs.getString("email"));
+                    users.put(user);
+                }
+                JSONObject result = new JSONObject();
+                result.put("users", users);
+                sendJsonResponse(response, result, HttpServletResponse.SC_OK);
+            } else {
+                // Retrieve one user by ID
+                String[] parts = pathInfo.split("/");
+                if (parts.length != 2) {
+                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URL");
+                    return;
+                }
+                int id = Integer.parseInt(parts[1]);
+                String sql = "SELECT id, name, email FROM users WHERE id = ?";
+                PreparedStatement ps = conn.prepareStatement(sql);
+                ps.setInt(1, id);
+                ResultSet rs = ps.executeQuery();
+
+                if (rs.next()) {
+                    JSONObject user = new JSONObject();
+                    user.put("id", rs.getInt("id"));
+                    user.put("name", rs.getString("name"));
+                    user.put("email", rs.getString("email"));
+                    sendJsonResponse(response, user, HttpServletResponse.SC_OK);
+                } else {
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND, "User not found");
+                }
+            }
+        } catch (SQLException e) {
+            throw new ServletException("Database access error", e);
+        }
+    }
+
+    // POST /users → create new user
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        JSONObject body = parseRequestBody(request);
+        String name = body.optString("name");
+        String email = body.optString("email");
+
+        if (name.isEmpty() || email.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Name and email are required");
+            return;
+        }
+
+        try (Connection conn = DriverManager.getConnection(URL)) {
+            String sql = "INSERT INTO users (name, email) VALUES (?, ?) RETURNING id";
+            PreparedStatement ps = conn.prepareStatement(sql);
+            ps.setString(1, name);
+            ps.setString(2, email);
+            ResultSet rs = ps.executeQuery();
+
+            if (rs.next()) {
+                int newId = rs.getInt("id");
+                JSONObject created = new JSONObject();
+                created.put("id", newId);
+                created.put("name", name);
+                created.put("email", email);
+                sendJsonResponse(response, created, HttpServletResponse.SC_CREATED);
+            } else {
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to create user");
+            }
+        } catch (SQLException e) {
+            throw new ServletException("Database access error", e);
+        }
+    }
+
+    // PUT /users/{id} → update existing user
+    @Override
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String pathInfo = request.getPathInfo(); // expect "/{id}"
+        if (pathInfo == null || pathInfo.equals("/") || pathInfo.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "User ID is required in URL");
+            return;
+        }
+        String[] parts = pathInfo.split("/");
+        if (parts.length != 2) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URL");
+            return;
+        }
+        int id = Integer.parseInt(parts[1]);
+        JSONObject body = parseRequestBody(request);
+        String name = body.optString("name");
+        String email = body.optString("email");
+
+        try (Connection conn = DriverManager.getConnection(URL)) {
+            String sql = "UPDATE users SET name = ?, email = ? WHERE id = ?";
+            PreparedStatement ps = conn.prepareStatement(sql);
+            ps.setString(1, name);
+            ps.setString(2, email);
+            ps.setInt(3, id);
+            int affected = ps.executeUpdate();
+
+            if (affected > 0) {
+                JSONObject updated = new JSONObject();
+                updated.put("id", id);
+                updated.put("name", name);
+                updated.put("email", email);
+                sendJsonResponse(response, updated, HttpServletResponse.SC_OK);
+            } else {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND, "User not found");
+            }
+        } catch (SQLException e) {
+            throw new ServletException("Database access error", e);
+        }
+    }
+
+    // DELETE /users/{id} → delete user
+    @Override
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String pathInfo = request.getPathInfo(); // expect "/{id}"
+        if (pathInfo == null || pathInfo.equals("/") || pathInfo.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "User ID is required in URL");
+            return;
+        }
+        String[] parts = pathInfo.split("/");
+        if (parts.length != 2) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URL");
+            return;
+        }
+        int id = Integer.parseInt(parts[1]);
+
+        try (Connection conn = DriverManager.getConnection(URL)) {
+            String sql = "DELETE FROM users WHERE id = ?";
+            PreparedStatement ps = conn.prepareStatement(sql);
+            ps.setInt(1, id);
+            int affected = ps.executeUpdate();
+
+            if (affected > 0) {
+                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            } else {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND, "User not found");
+            }
+        } catch (SQLException e) {
+            throw new ServletException("Database access error", e);
+        }
+    }
+}

--- a/week4/ServletPractice/src/main/webapp/WEB-INF/web.xml
+++ b/week4/ServletPractice/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+    <!-- Map UserServlet to /users/* -->
+    <servlet>
+        <servlet-name>UserServlet</servlet-name>
+        <servlet-class>com.example.servlet.UserServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>UserServlet</servlet-name>
+        <url-pattern>/users/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
feat: add Java Servlet CRUD project for PostgreSQL

- Initialize Maven webapp (`packaging: war`) with `ServletPractice` artifact
- Add dependencies:
  • Jakarta Servlet API 6.1.0 (scope: provided)
  • PostgreSQL JDBC Driver 42.7.6
  • org.json 20250517
- Configure `<build>`:
  • Set `<finalName>` to “user-crud-servlet”
  • Include `maven-compiler-plugin` (Java 1.8)
  • Include `maven-war-plugin` (disable failOnMissingWebXml)
- Create `UserServlet.java` under `com.example.servlet`:
  • `@WebServlet("/users/*")` with `doGet`/`doPost`/`doPut`/`doDelete` methods
  • JDBC logic to connect to PostgreSQL, parse JSON requests, produce JSON responses
- Add `src/main/webapp/WEB-INF/web.xml` (Jakarta 6.0 schema) mapping `com.example.servlet.UserServlet` → `/users/*`
- Build WAR: `mvn clean package` → `target/user-crud-servlet.war`
